### PR TITLE
Fix: guard against undefined conversionValue

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -261,7 +261,7 @@ if (eventModel.user_data != null && eventModel.user_data.leadID != null) {
 const eventID = eventDataOverride.eventId || data.eventId || eventModel.eventId || eventModel.event_id || '';
 const conversionCurrency = eventDataOverride.currency || eventModel.currency || '';
 const conversionAmount = eventDataOverride.amount || eventModel.value || '0';
-const conversionValue = JSON.parse(data.conversionValue) || {
+const conversionValue = data.conversionValue ? JSON.parse(data.conversionValue) : {
     currencyCode: conversionCurrency,
     amount: conversionAmount.toString()
 };


### PR DESCRIPTION
## Summary
- Fixes #14 — `JSON.parse(data.conversionValue)` crashes when `conversionValue` is undefined
- Changed from `JSON.parse(data.conversionValue) || { ... }` to a ternary check: `data.conversionValue ? JSON.parse(data.conversionValue) : { ... }`
- The fallback object with `currencyCode` and `amount` is now used correctly when no conversion value is provided

## Test plan
- [ ] Deploy tag to a GTM container without setting `conversionValue`
- [ ] Verify the tag fires without errors and uses the fallback currency/amount values
- [ ] Verify existing behavior is unchanged when `conversionValue` is provided