### PR TITLE
Fix user_data.address extraction to handle array format

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -232,7 +232,8 @@ const linkedin_api_version = '202503'; // LinkedIn API version (valid for 1 year
 // Input / Event Data Setup
 const eventModel = getAllEventData();
 const user_data = eventModel.user_data || {};
-const user_address = user_data.address || {};
+const user_address_raw = user_data.address || {};
+const user_address = getType(user_address_raw) === 'array' ? (user_address_raw[0] || {}) : user_address_raw;
 const eventDataOverride = makeOverrideTableMap(data.eventData);
 const userIdsOverride = makeOverrideTableMap(data.userIds);
 const userInfoOverride = makeOverrideTableMap(data.userInfo);


### PR DESCRIPTION
## Summary

Fixes #10.

`user_data.address` can be either a plain object or an array (e.g., `address[0]`). The current code assumes it is always an object, which causes incorrect field extraction when an array is provided.

This change checks the type of `user_data.address` at initialization and extracts `address[0]` when it is an array, falling back to the object as-is otherwise. All downstream consumers (`getUserFirstName`, `getUserLastName`, `getUserCountryCode`) work unchanged.

## Changes

- `template.tpl`: Replace `const user_address = user_data.address || {};` with a two-step assignment that uses `getType()` (already imported) to detect arrays and unwrap the first element.