### PR TITLE
Read li_fat_id cookie for LinkedIn first-party ID

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -224,6 +224,7 @@ const sha256Sync = require('sha256Sync');
 const getType = require('getType');
 const encodeUriComponent = require('encodeUriComponent');
 const makeTableMap = require('makeTableMap');
+const getCookieValues = require('getCookieValues');
 
 // Constants
 const CONV_API_ENDPOINT = "https://api.linkedin.com/rest/conversionEvents/";
@@ -395,7 +396,10 @@ function getFirstPartyAdsTrackingUuid() {
     }
     const ga4UserPropPrefix = 'x-ga-mp2-user_properties.';
     const userLinkedinFirstPartyID = getEventData(ga4UserPropPrefix + 'linkedinFirstPartyId') || '';
-    return eventLinkedinFirstPartyID || userLinkedinFirstPartyID || '';
+    // Read li_fat_id cookie as fallback
+    const cookieValues = getCookieValues('li_fat_id');
+    const cookieLinkedinFirstPartyID = cookieValues && cookieValues.length > 0 ? cookieValues[0] : '';
+    return eventLinkedinFirstPartyID || userLinkedinFirstPartyID || cookieLinkedinFirstPartyID || '';
 }
 
 // Fallback lookup for user information
@@ -566,6 +570,39 @@ ___SERVER_PERMISSIONS___
           "value": {
             "type": 1,
             "string": "debug"
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "get_cookies",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "cookieAccess",
+          "value": {
+            "type": 1,
+            "string": "specific"
+          }
+        },
+        {
+          "key": "cookieNames",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 1,
+                "string": "li_fat_id"
+              }
+            ]
           }
         }
       ]


### PR DESCRIPTION
## Summary
- Adds `getCookieValues('li_fat_id')` as a fallback in `getFirstPartyAdsTrackingUuid()` so the template automatically reads LinkedIn's first-party cookie when the ID is not already provided via user overrides, event model user_data, or GA4 user properties.
- Adds the `get_cookies` server permission scoped specifically to the `li_fat_id` cookie name.

Closes #7