### PR TITLE
Bump API version to 202605 and add PLAINTEXT_IP_ADDRESS and GOOGLE_AID idType

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -93,6 +93,14 @@ ___TEMPLATE_PARAMETERS___
               {
                 "value": "moatID",
                 "displayValue": "ORACLE_MOAT_ID"
+              },
+              {
+                "value": "ipAddress",
+                "displayValue": "PLAINTEXT_IP_ADDRESS"
+              },
+              {
+                "value": "googleAid",
+                "displayValue": "GOOGLE_AID"
               }
             ]
           },
@@ -227,7 +235,7 @@ const makeTableMap = require('makeTableMap');
 
 // Constants
 const CONV_API_ENDPOINT = "https://api.linkedin.com/rest/conversionEvents/";
-const linkedin_api_version = '202503'; // LinkedIn API version (valid for 1 year from release)
+const linkedin_api_version = '202605'; // LinkedIn API version (valid for 1 year from release)
 
 // Input / Event Data Setup
 const eventModel = getAllEventData();
@@ -343,6 +351,14 @@ function getUserIds() {
         {
             idType: 'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID',
             idValue: getFirstPartyAdsTrackingUuid()
+        },
+        {
+            idType: 'PLAINTEXT_IP_ADDRESS',
+            idValue: getPlaintextIpAddress()
+        },
+        {
+            idType: 'GOOGLE_AID',
+            idValue: getGoogleAid()
         }
     ];
 
@@ -375,6 +391,15 @@ function getAcxiomId() {
 function getOracleMoatId() {
     return userIdsOverride.moatID || user_data.moatID || '';
 }
+
+function getPlaintextIpAddress() {
+    return userIdsOverride.ipAddress || user_data.ip_address || '';
+}
+
+function getGoogleAid() {
+    return userIdsOverride.googleAid || user_data.googleAid || user_data.gaid || '';
+}
+
 
 // Gets LinkedIn first-party UUID
 function getFirstPartyAdsTrackingUuid() {


### PR DESCRIPTION
## Summary

  Two related changes bundled into one commit:

  1. **API version bump.** Roll the `LinkedIn-Version` request header forward from `202503` (March 2025) to `202605` (May 2026). The single `linkedin_api_version` const is the source of truth for the header sent on every outbound POST to
  `https://api.linkedin.com/rest/conversionEvents/`.
  
  2. **Two new user identifier types.** Add support for `PLAINTEXT_IP_ADDRESS` (raw IPv4) and `GOOGLE_AID` (Google
  Advertising ID for mobile). Both are sent unhashed (LinkedIn hashes IP Address server-side).
  
     Plumbing:
     - Two new `selectItems` entries on the User IDs override dropdown (`ipAddress` → `PLAINTEXT_IP_ADDRESS`, `googleAid`→ `GOOGLE_AID`).
     - Two new entries appended to the `getUserIds()` payload array.
     - Two new getter functions: `getPlaintextIpAddress()` reads `userIdsOverride.ipAddress` then `user_data.ip_address`;
  `getGoogleAid()` reads `userIdsOverride.googleAid` then `user_data.googleAid` / `user_data.gaid`.

  Empty values continue to be stripped by the existing `.filter(userId => userId.idValue)` at the tail of `getUserIds()`,
  so unpopulated entries do not appear on the wire.

  No new `require()` imports or template permissions are needed. 